### PR TITLE
Associate HTTP requests to a SIP Call-ID in the logging for easier debugging

### DIFF
--- a/designer/src/main/java/org/restcomm/connect/rvd/model/steps/es/ExternalServiceStep.java
+++ b/designer/src/main/java/org/restcomm/connect/rvd/model/steps/es/ExternalServiceStep.java
@@ -26,6 +26,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.restcomm.connect.rvd.RvdConfiguration;
 import org.restcomm.connect.rvd.exceptions.ESRequestException;
 import org.restcomm.connect.rvd.exceptions.InterpreterException;
 import org.restcomm.connect.rvd.interpreter.Interpreter;
@@ -281,6 +282,8 @@ public class ExternalServiceStep extends Step {
                 if ( !RvdUtils.isEmpty(getUsername()) )
                     request.addHeader("Authorization", "Basic " + RvdUtils.buildHttpAuthorizationToken(getUsername(), getPassword()));
 
+                if (!RvdUtils.isEmpty(interpreter.getVariables().get(RvdConfiguration.CORE_VARIABLE_PREFIX + "CallSid")))
+                    request.addHeader("X-CallSid", interpreter.getVariables().get(RvdConfiguration.CORE_VARIABLE_PREFIX + "CallSid"));
                 response = client.execute( request );
             } else
             if ( getMethod() == null || getMethod().equals("GET") || getMethod().equals("DELETE") ) {
@@ -292,6 +295,9 @@ public class ExternalServiceStep extends Step {
 
                 if ( !RvdUtils.isEmpty(getUsername()) )
                     request.addHeader("Authorization", "Basic " + RvdUtils.buildHttpAuthorizationToken(getUsername(), getPassword()));
+
+                if (!RvdUtils.isEmpty(interpreter.getVariables().get(RvdConfiguration.CORE_VARIABLE_PREFIX + "CallSid")))
+                    request.addHeader("X-CallSid", interpreter.getVariables().get(RvdConfiguration.CORE_VARIABLE_PREFIX + "CallSid"));
                 response = client.execute( request );
             } else
                 throw new InterpreterException("Unknonwn HTTP method specified: " + getMethod() );


### PR DESCRIPTION
Adding a new header to External Service POST and GET requests, the new header is called X-CallSid and contains the core_CallSid value.

https://github.com/RestComm/Restcomm-Connect/issues/1303